### PR TITLE
this-should-fail-linter

### DIFF
--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -1,0 +1,29 @@
+# This workflow executes several linters on changed files based on languages used in your code base whenever
+# you push a code or open a pull request.
+#
+# You can adjust the behavior by modifying this file.
+# For more information, see:
+# https://github.com/github/super-linter
+name: Lint Code Base
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+jobs:
+  run-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          # Full git history is needed to get a proper list of changed files within `super-linter`
+          fetch-depth: 0
+
+      - name: Lint Code Base
+        uses: github/super-linter@v4
+        env:
+          VALIDATE_ALL_CODEBASE: true
+          DEFAULT_BRANCH: "main"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/testing.java
+++ b/testing.java
@@ -1,0 +1,18 @@
+public class Example {
+    public static void main(String[] args) {
+        int x = 1;
+        switch (x) {
+            case 1:
+                System.out.println("x is equal to 1");
+                break;
+            case 2:
+                System.out.println("x is equal to 2");
+                break;
+            default:
+                System.out.println("x is not equal to 1 or 2");
+        }
+    }
+}
+/* UnusedVariable: The variable args is declared but never used.
+EmptyBlock: The default block is empty. It’s generally considered a bad practice to have empty blocks because they can lead to bugs and make the code harder to read.
+MissingSwitchDefault: The switch statement doesn’t have a default case. It’s generally considered a good practice to include a default case in switch statements to handle unexpected values.*/

--- a/testing.java
+++ b/testing.java
@@ -9,7 +9,7 @@ public class Example {
                 System.out.println("x is equal to 2");
                 break;
             default:
-                System.out.println("x is not equal to 1 or 2");
+                
         }
     }
 }


### PR DESCRIPTION
this is testing the linter works this should fail because: UnusedVariable: The variable args is declared but never used.
MissingSwitchDefault: The switch statement doesn’t have a default case. It’s generally considered a good practice to include a default case in switch statements to handle unexpected values