### PR TITLE
US003 - View Capability a role belongs to

### DIFF
--- a/src/main/java/org/kainos/ea/cli/Role.java
+++ b/src/main/java/org/kainos/ea/cli/Role.java
@@ -65,9 +65,10 @@ public class Role {
         this.sharepointLink = sharepointLink;
     }
 
-    public Role(String roleName, String specification, String responsibilities, String sharepointLink) {
+    public Role(String roleName, String specification, String capabilityName, String responsibilities, String sharepointLink) {
         this.roleName = roleName;
         this.specification = specification;
+        this.capabilityName = capabilityName;
         this.responsibilities = responsibilities;
         this.sharepointLink = sharepointLink;
     }

--- a/src/main/java/org/kainos/ea/db/RoleDao.java
+++ b/src/main/java/org/kainos/ea/db/RoleDao.java
@@ -16,7 +16,7 @@ public class RoleDao {
         Connection c = DatabaseConnector.getConnection();
 
         Statement st = c.createStatement();
-        ResultSet rs = st.executeQuery("SELECT RoleName, Specification, Responsibilities, SharepointLink FROM `JobRole`;");
+        ResultSet rs = st.executeQuery("SELECT RoleName, Specification, CapabilityName, Responsibilities, SharepointLink FROM `JobRole`;");
 
         List<Role> roleList = new ArrayList<>();
 
@@ -24,6 +24,7 @@ public class RoleDao {
             Role jobRole = new Role(
                     rs.getString("RoleName"),
                     rs.getString("Specification"),
+                    rs.getString("CapabilityName"),
                     rs.getString("Responsibilities"),
                     rs.getString("SharepointLink")
             );


### PR DESCRIPTION
As a Kainos employee

I want to be able to see what capability each role falls within
So that I can see what capability the role is within Kainos corporate structure

Acceptance Criteria

Update the job roles list page to show the capability name each role belongs to

<img width="1399" alt="Screenshot 2023-12-06 at 11 36 43" src="https://github.com/Criofann/JobForge-API/assets/145450866/f9d3dbcf-9703-47e2-b169-5ac60e35fb9a">
- job-roles UI changed to include the capability name in table